### PR TITLE
Update Barotrauma to allow LUA install

### DIFF
--- a/barotrauma.kvp
+++ b/barotrauma.kvp
@@ -18,7 +18,7 @@ Meta.ExtraSetupStepsURI=https://discourse.cubecoders.com/docs?topic=3952?utm_sou
 Meta.Prerequisites=[]
 Meta.ExtraContainerPackages=[]
 Meta.ConfigReleaseState=NotSpecified
-Meta.AppConfigId=2bb03c90-d662-4e3c-beca-ad136aac973b
+Meta.AppConfigId=2bb03c90-d662-4e3c-beca-ad136aac973c
 Meta.ConfigVersion=1.1
 App.DisplayName=Barotrauma
 App.RootDir=./barotrauma/

--- a/barotraumaconfig.json
+++ b/barotraumaconfig.json
@@ -1235,5 +1235,22 @@
             "strict": "Strict",
             "custom": "Custom"
         }
+    },
+    {
+        "DisplayName": "Install LUA",
+        "Category": "Updates",
+        "Subcategory": "Server Updates:system_update_alt:-1",
+        "Description": "Auto-installs Lua when the server is updated.",
+        "Keywords": "install,lua",
+        "FieldName": "LUA",
+        "InputType": "checkbox",
+        "IsFlagArgument": false,
+        "ParamFieldName": "LUA",
+        "IncludeInCommandLine": false,
+        "DefaultValue": "false",
+        "EnumValues": {
+            "False": "false",
+            "True": "true"
+        }
     }
 ]

--- a/barotraumaupdates.json
+++ b/barotraumaupdates.json
@@ -28,5 +28,29 @@
         "UpdateSourceData": "https://raw.githubusercontent.com/CubeCoders/AMPTemplates/main/barotraumaserversettings.xml",
         "UpdateSourceTarget": "{{$FullBaseDir}}",
         "UpdateSourceArgs": "serversettings.xml"
+    },
+    {
+        "UpdateStageName": "Download LUA",
+        "UpdateSourcePlatform": "Linux",
+        "UpdateSource": "FetchURL",
+        "UpdateSourceData": "https://github.com/evilfactory/LuaCsForBarotrauma/releases/download/latest/luacsforbarotrauma_patch_linux_client.zip",
+        "UpdateSourceTarget": "{{$FullBaseDir}}",
+        "UnzipUpdateSource": true,
+        "OverwriteExistingFiles": true,
+        "UpdateSourceConditionSetting": "LUA",
+        "UpdateSourceConditionValue": "true",
+        "DeleteAfterExtract": true
+    },
+    {
+        "UpdateStageName": "Download LUA",
+        "UpdateSourcePlatform": "Windows",
+        "UpdateSource": "FetchURL",
+        "UpdateSourceData": "https://github.com/evilfactory/LuaCsForBarotrauma/releases/download/latest/luacsforbarotrauma_patch_windows_client.zip",
+        "UpdateSourceTarget": "{{$FullBaseDir}}",
+        "UnzipUpdateSource": true,
+        "OverwriteExistingFiles": true,
+        "UpdateSourceConditionSetting": "LUA",
+        "UpdateSourceConditionValue": "true",
+        "DeleteAfterExtract": true
     }
 ]


### PR DESCRIPTION
Added a switch under Configuration>Updates>Server Updates to enable Lua install.
Anytime the update is ran the latest version of Lua is pulled and installed, needed for so many mods.
https://github.com/evilfactory/LuaCsForBarotrauma

![image](https://github.com/user-attachments/assets/296c55e3-8086-4aee-8323-8407b9804ade)

Support for Linux and Windows

A short section should probably be added to this site if this is merged explaining you need to flip the switch if you want Lua installed and to then run updates for it to install.
https://discourse.cubecoders.com/docs?topic=3952?utm_source=ampcreate&utm_content=barotrauma
