### PR TITLE
Add Primitive game mode to rustconfig.json

### DIFF
--- a/rustconfig.json
+++ b/rustconfig.json
@@ -411,6 +411,7 @@
         "DefaultValue": "vanilla",
         "EnumValues": {
             "vanilla": "Vanilla (default)",
+            "primitive": "Primitive",
             "softcore": "Softcore",
             "hardcore": "Hardcore"
         }


### PR DESCRIPTION
Added on line 414 "primitive": "Primitive", to rustconfig.json to add the game mode selection to the front end.